### PR TITLE
Update kogan_bladeless_fan.yaml

### DIFF
--- a/custom_components/tuya_local/devices/kogan_bladeless_fan.yaml
+++ b/custom_components/tuya_local/devices/kogan_bladeless_fan.yaml
@@ -6,7 +6,7 @@ products:
     name: Kogan KASBKSTFANSA
 primary_entity:
   entity: fan
-  translation_key: fan_with_presets
+#  translation_key: fan_with_presets
   dps:
     - id: 1
       type: boolean


### PR DESCRIPTION
translation_only_key was causing the devices not to be recognised by the integration. Removing the line fixed the issue.